### PR TITLE
fix: `destroy_files` function memory leak

### DIFF
--- a/src/c_functions.rs
+++ b/src/c_functions.rs
@@ -68,13 +68,13 @@ pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
 
     let file_list = Box::from_raw(file_list);
 
-    let files_path_ptrs: Vec<*mut c_char> = Vec::from_raw_parts(
+    let file_path_ptrs: Vec<*mut c_char> = Vec::from_raw_parts(
         file_list.data as *mut *mut c_char,
         file_list.length,
         file_list._capacity,
     );
 
-    for file_path_ptr in files_path_ptrs {
+    for file_path_ptr in file_path_ptrs {
         drop(CString::from_raw(file_path_ptr));
     }
 }

--- a/src/c_functions.rs
+++ b/src/c_functions.rs
@@ -61,9 +61,22 @@ pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut Fi
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_files(files: *mut FileList) {
-    if !files.is_null() {
-        drop(Vec::from_raw_parts(files, (*files).length, (*files)._capacity));
+pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
+    if file_list.is_null() {
+        // TODO: should we panic here?
+        return;
+    }
+
+    let file_list = Box::from_raw(file_list);
+
+    let files_path_ptrs: Vec<*mut c_char> = Vec::from_raw_parts(
+        file_list.data as *mut *mut c_char,
+        file_list.length,
+        file_list._capacity,
+    );
+
+    for file_path_ptr in files_path_ptrs {
+        drop(CString::from_raw(file_path_ptr));
     }
 }
 

--- a/src/c_functions.rs
+++ b/src/c_functions.rs
@@ -33,7 +33,6 @@ pub unsafe extern "C" fn create_workspace(
 }
 
 #[no_mangle]
-// TODO: Indexing item 0 of the returned array here yields a segfault. Any idea why?
 pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut FileList {
     if workspace.is_null() {
         return std::ptr::null_mut();

--- a/src/c_functions.rs
+++ b/src/c_functions.rs
@@ -16,9 +16,8 @@ pub unsafe extern "C" fn create_workspace(
     name: *const c_char,
     path: *const c_char,
 ) -> *mut Workspace {
-    if name.is_null() || path.is_null() {
-        return std::ptr::null_mut();
-    }
+    assert!(!name.is_null(), "Parameter `name` must not be `null`!");
+    assert!(!path.is_null(), "Parameter `path` must not be `null`!");
 
     let (name, path) = (
         std::ffi::CStr::from_ptr(name),
@@ -34,11 +33,10 @@ pub unsafe extern "C" fn create_workspace(
 
 #[no_mangle]
 pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut FileList {
-    if workspace.is_null() {
-        // TODO: should we panic here? Passing a null ptr to this function does not make sense
-        // If the caller tries to dereference the null ptr we return, the program will crash anyway
-        return std::ptr::null_mut();
-    }
+    assert!(
+        !workspace.is_null(),
+        "Parameter `workspace` must not be `null`!"
+    );
 
     let files = ManuallyDrop::new(
         (*workspace)
@@ -64,7 +62,6 @@ pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut Fi
 #[no_mangle]
 pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
     if file_list.is_null() {
-        // TODO: should we panic here? Passing a null ptr to this function does not make sense
         return;
     }
 
@@ -83,8 +80,9 @@ pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
 
 #[no_mangle]
 pub unsafe extern "C" fn destroy_workspace(workspace: *mut Workspace) {
-    if !workspace.is_null() {
-        // TODO: should we panic here? Passing a null ptr to this function does not make sense
-        drop(Box::from_raw(workspace));
+    if workspace.is_null() {
+        return;
     }
+
+    drop(Box::from_raw(workspace));
 }

--- a/src/c_functions.rs
+++ b/src/c_functions.rs
@@ -35,6 +35,8 @@ pub unsafe extern "C" fn create_workspace(
 #[no_mangle]
 pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut FileList {
     if workspace.is_null() {
+        // TODO: should we panic here? Passing a null ptr to this function does not make sense
+        // If the caller tries to dereference the null ptr we return, the program will crash anyway
         return std::ptr::null_mut();
     }
 
@@ -62,7 +64,7 @@ pub unsafe extern "C" fn workspace_files(workspace: *const Workspace) -> *mut Fi
 #[no_mangle]
 pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
     if file_list.is_null() {
-        // TODO: should we panic here?
+        // TODO: should we panic here? Passing a null ptr to this function does not make sense
         return;
     }
 
@@ -82,6 +84,7 @@ pub unsafe extern "C" fn destroy_files(file_list: *mut FileList) {
 #[no_mangle]
 pub unsafe extern "C" fn destroy_workspace(workspace: *mut Workspace) {
     if !workspace.is_null() {
+        // TODO: should we panic here? Passing a null ptr to this function does not make sense
         drop(Box::from_raw(workspace));
     }
 }


### PR DESCRIPTION
This pr should make the `destroy_files` function free the memory correctly, that was earlier allocated in the `workspace_files` function.

Automatic tests with memory analysis could be very useful. Haven't actually set up something like that on my own, but i can look into it.

@vhyrro  Maybe you can give your opinion on the todos i added. If I were to use this library in my application, I think I would want the library to crash if I passed in a value that didn't really make sense.